### PR TITLE
feat-12 : Add Loading Spinner for Import Operation #12

### DIFF
--- a/src/pages/Builder.jsx
+++ b/src/pages/Builder.jsx
@@ -143,6 +143,7 @@ export default function Dashboard() {
     const saved = localStorage.getItem("markdown-blocks");
     return saved ? JSON.parse(saved) : [];
   });
+  const [isImporting, setIsImporting] = useState(false);
   const [history, setHistory] = useState([[]]);
   const [historyIndex, setHistoryIndex] = useState(0);
   const [activeId, setActiveId] = useState(null);
@@ -261,6 +262,7 @@ export default function Dashboard() {
       const file = e.target.files?.[0];
       if (!file) return;
 
+       setIsImporting(true);
       try {
         const text = await file.text();
         const newBlocks = markdownToBlocks(text);
@@ -270,6 +272,9 @@ export default function Dashboard() {
       } catch (error) {
         toast.error("Failed to import file");
         console.log(error);
+      }
+      finally{
+        setIsImporting(false);
       }
     };
     input.click();
@@ -672,6 +677,12 @@ export default function Dashboard() {
             </div>
           </div>
         </SidebarInset>
+        {isImporting && (
+          <div className="absolute inset-0 bg-background/60 backdrop-blur-sm flex items-center justify-center z-50">
+            <div className="animate-spin rounded-full h-10 w-10 border-4 border-t-transparent border-primary"></div>
+            <span className="ml-3 font-medium">Importing...</span>
+          </div>
+        )}
 
         <DragOverlay>
           {activeId ? (


### PR DESCRIPTION
## Summary
This PR adds a loading spinner during markdown file import to provide users with immediate visual feedback while the operation is in progress.

## Problem
Users currently have no indication that an import is happening, which may seem like the UI is stuck or unresponsive.

## Solution
- Spinner displays during import and hides when complete
- Smooth experience even for large markdown files

## Code Changes
- Import logic updated in `Builder.jsx`

## Demo Screen Recoder

https://github.com/user-attachments/assets/70ca6e05-6c1a-4e3c-a318-cece2f7da31e

Fixes #12
