### PR TITLE
feat: Implement undo/redo keyboard shortcuts

### DIFF
--- a/src/pages/Builder.jsx
+++ b/src/pages/Builder.jsx
@@ -151,6 +151,26 @@ export default function Dashboard() {
     localStorage.setItem("markdown-blocks", JSON.stringify(blocks));
   }, [blocks]);
 
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      // Detect Ctrl+Z (Windows) or Command+Z (Mac) for Undo
+      if ((event.ctrlKey || event.metaKey) && event.key === "z" && !event.shiftKey) {
+        event.preventDefault();
+        handleUndo();
+      }
+      // Detect Ctrl+Y (Windows) or Command+Y (Mac) for Redo
+      else if ((event.ctrlKey || event.metaKey) && event.key === "y") {
+        event.preventDefault();
+        handleRedo();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [history, historyIndex]);
+
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {


### PR DESCRIPTION
## Description

This pull request introduces keyboard shortcuts for undo and redo functionality within the markdown builder.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] UI/UX improvement

## Changes Made

<!-- List the specific changes made in this PR -->

- Implemented a useEffect hook in Builder.jsx to add a global keydown event listener.
- Added logic to trigger the handleUndo and handleRedo functions when `Ctrl+Z` (or `Cmd+Z` on macOS), and`Ctrl+Y` (or `Cmd+Y` on macOS) are pressed, respectively.

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

N/A. This is a functional change and does not have a visual component.

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my changes locally
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Add any additional information or context about the PR -->

This implementation improves the editing workflow by providing standard keyboard shortcuts that users expect from a text-editing environment.