### PR TITLE
Improve and modernize Markdrop README for clarity and onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,223 @@
-<p align="center">
-  <img width="500" height="293" alt="markdrop_repo" src="https://github.com/user-attachments/assets/7ba9de7e-e4c0-44ee-8e39-3279311e25e8" />
+<div align="center" style="padding: 40px 16px; border-radius:20px; background: #f9fafb; box-shadow: 0 2px 8px #0001; max-width: 900px; margin: 32px auto;">
+
+<h1>🌟 Markdrop</h1>
+<p><em>A Powerful Visual Markdown Editor and Builder</em></p>
+
+<p>
+  <a href="./.github/ROADMAP.md"><strong>🗺️ Roadmap</strong></a> •
+  <a href="./CONTRIBUTING.md"><strong>🤝 Contributing Guide</strong></a> •
+  <a href="./CODE_OF_CONDUCT.md"><strong>📜 Code of Conduct</strong></a> •
+  <a href="./.github/COMMUNITY_GUIDELINES.md"><strong>👥 Community Guidelines</strong></a> •
+  <a href="./.github/COMMIT_CONVENTION.md"><strong>🧩 Commit Convention</strong></a>
 </p>
+
+</div>
+
+---
+
+<div align="center" style="max-width:850px; margin:auto;">
+
+## 🚀 Overview
+
+<strong>Markdrop</strong> is an advanced <strong>visual Markdown editor and builder</strong> designed for individuals and teams to craft elegant documentation, README files, and technical content effortlessly.
+
+With its <strong>drag‑and‑drop interface</strong>, real‑time preview, customizable content blocks, and multi‑format export, Markdrop allows creators to focus on content, not syntax.
+
+<span style="color: #888;">
+Built with <strong>React</strong>, <strong>TypeScript</strong>, and powered by the modern <strong>pnpm</strong> workflow and <strong>Biome</strong> for consistent code quality.
+</span>
+</div>
+
+---
+
+<div align="center" style="max-width:850px; margin:auto;">
+  
+## ✨ Key Features
+</div>
+
+<ul style="max-width:800px; margin:auto;">
+  <li><b>Visual Markdown Editing</b> — Compose rich content without learning syntax.</li>
+  <li><b>Drag‑and‑Drop Blocks</b> — Insert images, lists, and code snippets easily.</li>
+  <li><b>Live Preview</b> — Edit visually with instant, rendered output.</li>
+  <li><b>Reusable Components</b> — Design with consistency using modular blocks.</li>
+  <li><b>Multi‑Format Export</b> — Export seamlessly to <code>.md</code>, <code>.html</code>, or <code>.pdf</code>.</li>
+  <li><b>Code Quality by Design</b> — Maintained using Biome for linting and formatting.</li>
+  <li><b>Cross‑Platform</b> — Runs smoothly on macOS, Windows, and Linux.</li>
+</ul>
+
+---
+
+<div align="center" style="max-width:780px; margin:auto;">
+  
+## 🧰 Technology Stack
+</div>
+
+<table align="center" style="margin-left:auto;margin-right:auto;">
+<thead>
+<tr><th>Category</th><th>Technology</th></tr>
+</thead>
+<tbody>
+<tr><td>Frontend</td><td>React, TypeScript</td></tr>
+<tr><td>Package Manager</td><td>pnpm</td></tr>
+<tr><td>Linting & Formatting</td><td>Biome</td></tr>
+<tr><td>Build Tool</td><td>Vite</td></tr>
+<tr><td>Styling</td><td>CSS Modules / Tailwind</td></tr>
+<tr><td>Version Control</td><td>Git &amp; GitHub</td></tr>
+</tbody>
+</table>
+
+---
+
+<div align="center" style="max-width:780px; margin:auto;">
+
+## ⚙️ Getting Started
+
+</div>
+
+### 1. Fork the Repository
+
+Fork **Markdrop** on GitHub to your personal account.
+
+### 2. Clone Your Fork
+git clone https://github.com/aqsaaqeel/Markdrop.git
+cd Markdrop
+
+text
+
+### 3. Install Dependencies
+
+pnpm install
+
+text
+
+### 4. Create a New Branch
+
+git checkout -b feature/your-feature-name
+
+text
+
+---
+
+<div align="center" style="max-width:780px; margin:auto;">
+  
+## 💻 Development
+</div>
+
+Start the local development server:
+
+pnpm dev
+
+text
+
+Once running, open:
+http://localhost:5173
+
+text
+Use this environment for local testing, developing blocks, or previewing new features.
+
+---
+
+<div align="center" style="max-width:780px; margin:auto;">
+  
+## 🧹 Code Quality
+</div>
+
+Markdrop uses **Biome** for uniform linting and formatting.
+
+pnpm lint # Run linter
+pnpm format # Format code
+pnpm clean # Full cleanup before commits
+
+text
+
+---
+
+<div align="center" style="max-width:780px; margin:auto;">
+  
+## 🛠️ Making Changes
+</div>
+
+1. Work in your feature branch and test locally.
+2. Run `pnpm clean` before every commit.
+3. Use meaningful commit messages, e.g.:
+git commit -m "feat(editor): improved markdown block rearrangement"
+
+text
+4. Push and open a pull request against the main branch.
+
+---
+
+<div align="center" style="max-width:780px; margin:auto;">
+
+## 🔁 Pull Request Guidelines
+</div>
+
+- Each PR should cover **one feature or fix**.
+- Clear, descriptive **titles and commit remarks**.
+- Attach **screenshots** for UI-related changes.
+- Reference issues (e.g., `Closes #12`).
+- Passing **lint/build** checks required.
+- Respond quickly to any review feedback.
+
+---
+
+<div align="center" style="max-width:780px; margin:auto;">
+
+## 💡 Code Style
+</div>
+
+- Use **TypeScript** for type safety.
+- Focus on **React best practices**.
+- Keep components **modular** and **named clearly**.
+- Comment on complex logic.
+- Consistent import structure.
+
+---
+
+<div align="center" style="max-width:780px; margin:auto;">
+
+## 🧱 Project Structure
+</div>
+
+src/
+├── components/ # Reusable UI components
+├── pages/ # Page-level views
+├── lib/ # Utilities and helpers
+├── styles/ # CSS/Tailwind modules
+└── assets/ # Static content
+
+text
+This structure promotes maintainability and scalability.
+
+---
+
+<div align="center" style="max-width:780px; margin:auto;">
+  
+## 🔄 Contribution Workflow
+
+</div>
+
+**Fork → Clone → Branch → Develop → Lint → Commit → Push → PR**
+
+All PRs must pass checks and will be reviewed for clarity and code quality.
+
+---
+
+<div align="center" style="max-width:780px; margin:auto;">
+  
+## 🙌 Acknowledgements
+
+Markdrop draws inspiration from Markdown’s simplicity and the ease of visual editing. Thanks to all contributors advancing modern documentation.
+</div>
+
+---
+
+<div align="center" style="max-width:780px; margin:auto;">
+  
+## 🧾 License
+
+**GNU General Public License v3.0 (GPL‑3.0)**  
+Feel free to use, modify, and distribute under the terms of this open-source license.
+
+</div>
+


### PR DESCRIPTION
I'd like to revamp the current README to make it more descriptive and organization-friendly. The new version would align with the repository’s ‘About’ section and include:
- Clear overview of Markdrop as a visual Markdown editor and builder
- Expanded Getting Started, Development, and Code Quality sections (based on the current CONTRIBUTING guide)
- Structured project architecture and usage examples
- Professional formatting and consistent tone

**Why**
Improving the README enhances first impressions, helps new contributors onboard faster, and ensures the project looks professional to potential users and organizations.

