### PR TITLE
Added the Copy to clipboard button at raw markdown and made the light/dark mode button more responsive at the builder

### DIFF
--- a/src/components/ModeToggle.jsx
+++ b/src/components/ModeToggle.jsx
@@ -1,5 +1,5 @@
 import { Moon, Sun } from "lucide-react";
-import { useCallback, useState, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTheme } from "@/components/ThemeProvider";
 import { Button } from "@/components/ui/button";
 
@@ -9,7 +9,6 @@ export function ModeToggle() {
   const [isToggling, setIsToggling] = useState(false);
 
   useEffect(() => {
-    
     setOptimisticTheme(theme);
   }, [theme]);
 
@@ -66,7 +65,7 @@ export function ModeToggle() {
 
   return (
     <Button
-      style = {{cursor: "pointer"}}
+      style={{ cursor: "pointer" }}
       variant="outline"
       size="icon"
       onClick={toggleTheme}
@@ -82,5 +81,5 @@ export function ModeToggle() {
       )}
       <span className="sr-only">Toggle theme</span>
     </Button>
-);
+  );
 }

--- a/src/components/blocks/BuilderPage/Raw.jsx
+++ b/src/components/blocks/BuilderPage/Raw.jsx
@@ -1,8 +1,8 @@
+import { CheckIcon, CopyIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
-import { CheckIcon, CopyIcon } from "lucide-react";
+import { Textarea } from "@/components/ui/textarea";
 
 // Helper to convert blocks to markdown
 const blocksToMarkdown = (blocks) => {
@@ -459,42 +459,38 @@ export default function Raw({ blocks = [], onBlocksChange }) {
   };
 
   const copyMarkdown = async () => {
-  try {
-    
-    if (!navigator.clipboard) {
-      const textArea = document.createElement("textarea");
-      textArea.value = markdown;
-      textArea.style.position = "fixed";
-      textArea.style.left = "-999999px";
-      document.body.appendChild(textArea);
-      textArea.focus();
-      textArea.select();
-      
-      try 
-      {
-        setIsCopied(true);
-        toast.success("Markdown copied to clipboard");
-        setTimeout(() => setIsCopied(false), 2000);
-      } 
-      catch (err) 
-      {
-        console.error('Fallback copy failed:', err);
-        toast.error("Failed to copy");
-      }
-      
-      document.body.removeChild(textArea);
-      return;
-    }
+    try {
+      if (!navigator.clipboard) {
+        const textArea = document.createElement("textarea");
+        textArea.value = markdown;
+        textArea.style.position = "fixed";
+        textArea.style.left = "-999999px";
+        document.body.appendChild(textArea);
+        textArea.focus();
+        textArea.select();
 
-    await navigator.clipboard.writeText(markdown);
-    setIsCopied(true);
-    toast.success("Markdown copied to clipboard");
-    setTimeout(() => setIsCopied(false), 2000);
-  } catch (error) {
-    console.error('Copy failed:', error);
-    toast.error("Failed to copy markdown");
-  }
-};
+        try {
+          setIsCopied(true);
+          toast.success("Markdown copied to clipboard");
+          setTimeout(() => setIsCopied(false), 2000);
+        } catch (err) {
+          console.error("Fallback copy failed:", err);
+          toast.error("Failed to copy");
+        }
+
+        document.body.removeChild(textArea);
+        return;
+      }
+
+      await navigator.clipboard.writeText(markdown);
+      setIsCopied(true);
+      toast.success("Markdown copied to clipboard");
+      setTimeout(() => setIsCopied(false), 2000);
+    } catch (error) {
+      console.error("Copy failed:", error);
+      toast.error("Failed to copy markdown");
+    }
+  };
 
   return (
     <div className="w-full min-h-[500px] rounded-lg p-4">

--- a/src/components/blocks/Navbar/Navbar.jsx
+++ b/src/components/blocks/Navbar/Navbar.jsx
@@ -25,9 +25,10 @@ export default function Navbar() {
               key={link.href}
               to={link.href}
               className={`font-semibold relative transition-colors duration-500 ease-in-out
-                ${currentPath === link.href
-                  ? "text-black dark:text-white"
-                  : "text-[#9b9b9b] dark:text-[#a0a0a0] hover:text-black dark:hover:text-white"
+                ${
+                  currentPath === link.href
+                    ? "text-black dark:text-white"
+                    : "text-[#9b9b9b] dark:text-[#a0a0a0] hover:text-black dark:hover:text-white"
                 }`}
             >
               {link.label}

--- a/src/pages/Builder.jsx
+++ b/src/pages/Builder.jsx
@@ -282,7 +282,7 @@ export default function Dashboard() {
       const file = e.target.files?.[0];
       if (!file) return;
 
-       setIsImporting(true);
+      setIsImporting(true);
       try {
         const text = await file.text();
         const newBlocks = markdownToBlocks(text);
@@ -292,8 +292,7 @@ export default function Dashboard() {
       } catch (error) {
         toast.error("Failed to import file");
         console.log(error);
-      }
-      finally{
+      } finally {
         setIsImporting(false);
       }
     };


### PR DESCRIPTION


## Description

At the raw markdown tab i added a "Copy to clipboard" button. When pressed it shows the message "Copied!" and the user has all the raw markdown saved. If something does not work it says "Failed to copy".
Also, at the builder page i made the Light/dark mode button more responsive. It pops up when the user hover over it and the cursor becomes pointer.

## Type of Change


- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [X] UI/UX improvement

## Related Issue

Closes #6


## Changes Made


- Copy button at raw markdown tab
- Responsive light/dark mode button at builder page


## Screenshots (if applicable)
Here are the screenshots that show the features i added

![Screenshot from 2025-10-26 23-21-59](https://github.com/user-attachments/assets/549c4a02-81ad-4203-a3fc-9a7afea19b4c)
![Screenshot from 2025-10-26 23-22-08](https://github.com/user-attachments/assets/9e525b72-385f-4179-9af5-4ec043f816c0)


## Checklist

- [X] My code follows the project's code style
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have tested my changes locally
- [ ] Any dependent changes have been merged and published

