### PR TITLE
fix(preview): resolve corrupted code block display in Preview component

### DIFF
--- a/src/components/blocks/BuilderPage/Preview.jsx
+++ b/src/components/blocks/BuilderPage/Preview.jsx
@@ -23,7 +23,7 @@ const blocksToMarkdown = (blocks) => {
         case "blockquote":
           return `> ${block.content}`;
         case "code":
-          return `\n${block.content}`;
+          return block.content;
         case "ul":
           return block.content;
         case "ol":
@@ -181,13 +181,20 @@ export default function Preview({ blocks = [] }) {
                 </code>
               ) : (
                 <code
-                  className="block bg-muted p-4 rounded-md my-4 overflow-x-auto text-sm font-mono"
+                  className="block bg-transparent p-0 text-sm font-mono whitespace-pre-wrap"
                   {...props}
                 >
                   {children}
                 </code>
               ),
-            pre: ({ children }) => <>{children}</>,
+            pre: ({ children, ...props }) => (
+              <pre
+                className="bg-muted p-4 rounded-md my-4 overflow-x-auto text-sm font-mono whitespace-pre-wrap"
+                {...props}
+              >
+                {children}
+              </pre>
+            ),
             blockquote: ({ ...props }) => (
               <blockquote
                 className="border-l-4 border-border pl-4 my-4 text-muted-foreground"


### PR DESCRIPTION
## Description

When using code block markdown, the Preview display is corrupted as line breaks are not properly displayed.

This closes #[36](https://github.com/rakheOmar/Markdrop/issues/36)

## Type of Change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] UI/UX improvement

## Changes Made

- Fix code block content preservation (Preview.jsx:26)
- Enhanced code block styling (Preview.jsx:190-197)
- Optimized inline code styling (Preview.jsx:183-188)

## Screenshots (if applicable)

| Before | After |
| ------ | ----- |
|    
<img width="1548" height="1344" alt="Preview" src="https://github.com/user-attachments/assets/1d8147d1-b209-4199-a79f-0abe162038f6" />
    |     
<img width="1548" height="1344" alt="Fixed" src="https://github.com/user-attachments/assets/adacc4f2-ccea-4eec-be1c-0b66656fcc21" />
  |

## Checklist

<!-- Mark completed items with an "x" -->

- [x ] My code follows the project's code style
- [ x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] I have tested my changes locally
- [x] Any dependent changes have been merged and published

## Additional Notes


